### PR TITLE
gx publish 0.1.1

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.0: Qmd1HfU1m9mR839VhGp5JrcvteF7b5LoTtPMqcxLuriCTY
+0.1.1: QmRcFemyJ8JjkMhErTAapQqs411JxD6YQRbtCmwAfnGe24

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",
+      "hash": "QmdxUuburamoF6zF9qjeQC4WYcWGbWuRmdLacMEsW8ioD8",
       "name": "gogo-protobuf",
       "version": "0.0.0"
     }
@@ -19,6 +19,6 @@
   "license": "MIT",
   "name": "go-libp2p-pubsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }
 


### PR DESCRIPTION
This is merely for avoiding dups in our gx dep trees.